### PR TITLE
test: declare pytest-asyncio so the async attach tests actually run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,13 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.4.1",
+    "pytest-asyncio>=1.0.0",
     "ruff>=0.12.1",
     "ipykernel>=6.29.5",
 ]
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_browser_attach.py
+++ b/tests/test_browser_attach.py
@@ -135,8 +135,10 @@ async def test_close_browser_attach_does_not_terminate_process():
     browser = Browser(BrowserConfig(attach_to_existing=True))
     browser._client = MagicMock()
     browser._client.__aexit__ = AsyncMock(return_value=None)
-    browser._process = MagicMock()
+    process = MagicMock()
+    browser._process = process
 
     await browser.close_browser()
 
-    browser._process.terminate.assert_not_called()
+    process.terminate.assert_not_called()
+    process.kill.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1709,6 +1709,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2265,6 +2277,7 @@ dependencies = [
 dev = [
     { name = "ipykernel" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -2289,6 +2302,7 @@ requires-dist = [
     { name = "pymupdf", specifier = ">=1.24.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.1" },


### PR DESCRIPTION
## Problem

`tests/test_browser_attach.py` has six `@pytest.mark.asyncio` tests, but `pytest-asyncio` is not declared in the `dev` extra. After a clean `pip install -e '.[dev]'`, all six fail:

```
FAILED tests/test_browser_attach.py::test_resolve_ws_url_attach_uses_devtools_active_port
  - Failed: async def functions are not natively supported.
... (6 total)
PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?
```

So the entire attach-mode test surface — WS URL resolution, port polling, and the guarantee that attach mode never kills the user's browser — is not currently being exercised.

## What declaring it revealed

With `pytest-asyncio` installed, five of the six pass and one genuinely fails:

```
FAILED tests/test_browser_attach.py::test_close_browser_attach_does_not_terminate_process
  - AttributeError: 'NoneType' object has no attribute 'terminate'
```

`close_browser()` clears `self._process`, so reading `browser._process.terminate` *after* the call dereferences `None`. The assertion could never have run. Capturing the mock in a local before the call fixes it, and I added `kill.assert_not_called()` alongside — attach mode should leave the user's browser alone by either path.

## Changes

- `pyproject.toml`: add `pytest-asyncio>=1.0.0` to the `dev` extra, and set `asyncio_default_fixture_loop_scope = "function"` to silence the unset-default deprecation warning.
- `uv.lock`: regenerated for the new dependency.
- `tests/test_browser_attach.py`: capture the process mock before `close_browser()`, and assert `kill()` wasn't called either.

## Result

`pytest tests/` goes from **1 failed, 19 passed** to **20 passed**.

Branches off current `main`; no other files touched.